### PR TITLE
Data conversion tool + DB game and platform implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+*.json

--- a/GameLauncher_Console/DataConversionTool/App.config
+++ b/GameLauncher_Console/DataConversionTool/App.config
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+  </startup>
+  <entityFramework>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+    </providers>
+  </entityFramework>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
+  </system.data>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/GameLauncher_Console/DataConversionTool/Converter.cs
+++ b/GameLauncher_Console/DataConversionTool/Converter.cs
@@ -1,0 +1,92 @@
+﻿using GameLauncher_Console;
+using SqlDB;
+using System.Collections.Generic;
+using static CGame_Test.CGame;
+
+namespace DataConversionTool
+{
+    public class CConverter
+    {
+        /// <summary>
+        /// Enum for convertion mode
+        /// </summary>
+        public enum ConvertMode
+        {
+            cModeUnknown = 0x00,
+            cModeVerify  = 0x01,
+            cModeApply   = 0x02,
+        }
+
+        private readonly ConvertMode Mode;
+
+        public CConverter(ConvertMode mode)
+        {
+            Mode = mode;
+        }
+
+        /// <summary>
+        /// Begin the data conversion
+        /// </summary>
+        /// <returns>True if in 'verify' mode or on conversion success</returns>
+        public bool ConvertData()
+        {
+            // TODO: Open database connection
+            // TODO: Load games and put into a GameSets (platform to game objects)
+            // TODO: Display platform count, games per platform and each game data
+            // TODO: Log the data as well
+            // TODO: Save the games to database (show the counter too while doing it)
+            // TODO: Load the games from database (to a new collection) and compare against the original
+            // TODO: Is success, print success - otherwise remove data from DB table (rollback?) and print failure
+            bool success = true;
+            if (Mode == ConvertMode.cModeApply)
+            {
+                success = CSqlDB.Instance.Open(true) == System.Data.SQLite.SQLiteErrorCode.Ok;
+                if (!success)
+                {
+                    CInputOutput.Log("ERROR: Could not open or create the database.");
+                    return success;
+                }
+            }
+            // Load games from JSON
+            success = CJsonWrapper.ImportFromJSON(out CConfig.Configuration config, out CConfig.Hotkeys keys, out CConfig.Colours cols, out List<CGameData.CMatch> matches);
+            if(!success)
+            {
+                CInputOutput.Log("ERROR: Could not load games from the JSON file");
+                return success;
+            }
+            Dictionary<string, int> platforms = CGameData.GetPlatforms();
+            HashSet<CGameData.CGame> allGames = CGameData.GetPlatformGameList(CGameData.GamePlatform.All);
+            CInputOutput.LogGameData(platforms, allGames);
+
+            if(Mode == ConvertMode.cModeApply)
+            {
+                // Add platforms to the database
+
+
+                // Add the games to the database
+                List<GameObject> gamesDB = new List<GameObject>();
+                foreach(CGameData.CGame game in allGames)
+                {
+                    gamesDB.Add(new GameObject());
+                }
+            }
+            else
+            {
+                CInputOutput.Log("Mode is 'verify' - no changes have been made");
+                CInputOutput.Log("In order to perform conversion, run the program in 'apply' mode");
+                CInputOutput.Log("**** END ****");
+            }
+
+            return success;
+        }
+
+        private Dictionary<string, int> AddPlatformsToDB(List<string> platforms)
+        {
+            Dictionary<string, int> platformsDB = new Dictionary<string, int>();
+
+            // TODO;
+
+            return platformsDB;
+        }
+    }
+}

--- a/GameLauncher_Console/DataConversionTool/DataConversionTool.csproj
+++ b/GameLauncher_Console/DataConversionTool/DataConversionTool.csproj
@@ -1,0 +1,91 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\EntityFramework.6.3.0\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{92A97D68-92B7-4348-9275-BC3E9D0E8941}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>DataConversionTool</RootNamespace>
+    <AssemblyName>DataConversionTool</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.113.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.113.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Converter.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="InputOutput.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GameLauncher_Console\GameLauncher_Console.csproj">
+      <Project>{4EBCEF5B-1A8A-42FB-81DB-446A14ED15D1}</Project>
+      <Name>GameLauncher_Console</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.3.0\build\EntityFramework.props'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.3.0\build\EntityFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
+  </Target>
+  <Import Project="..\packages\EntityFramework.6.3.0\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.3.0\build\EntityFramework.targets')" />
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.113.3\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
+</Project>

--- a/GameLauncher_Console/DataConversionTool/InputOutput.cs
+++ b/GameLauncher_Console/DataConversionTool/InputOutput.cs
@@ -1,0 +1,94 @@
+﻿using GameLauncher_Console;
+using Logger;
+using System;
+using System.Collections.Generic;
+
+namespace DataConversionTool
+{
+    public class CInputOutput
+    {
+        // Command-line option const
+        private const string FLAG_APPLY = "apply";
+        private const string FLAG_VERIFY = "verify";
+
+        private static readonly string[] HELP =
+        {
+        //  0|-------|---------|---------|---------|---------|---------|---------|---------|80
+            "This conversion tool will migrate the game data from JSON to SQLite database",
+            "Command line parameters:",
+            "-verify: Load, verify and display game data. No migration will happen.",
+            "-apply: Perform the same checks as 'verify' and also migrate data to the DB",
+        };
+
+        public CInputOutput()
+        {
+
+        }
+
+        /// <summary>
+        /// Determine tool mode from input string
+        /// </summary>
+        /// <param name="mode">Input string</param>
+        /// <returns>ConvertMode enum</returns>
+        public CConverter.ConvertMode DetermineMode(string mode)
+        {
+            switch(mode)
+            {
+                case FLAG_VERIFY:
+                    return CConverter.ConvertMode.cModeVerify;
+                        
+                case FLAG_APPLY:
+                    return CConverter.ConvertMode.cModeApply;
+
+                default:
+                    return CConverter.ConvertMode.cModeUnknown;
+            }
+        }
+
+        /// <summary>
+        /// Write help array to donsole
+        /// </summary>
+        public void ShowHelp()
+        {
+            Console.Clear();
+            foreach(string s in HELP)
+            {
+                Console.WriteLine(s);
+            }
+        }
+
+        /// <summary>
+        /// Write message to console and log file
+        /// </summary>
+        /// <param name="message">The message</param>
+        public static void Log(string message)
+        {
+            Console.WriteLine(message);
+            CLogger.LogInfo(message);
+        }
+
+        /// <summary>
+        /// Log game and platform statistics
+        /// </summary>
+        /// <param name="games"></param>
+        public static void LogGameData(Dictionary<string, int> platforms, HashSet<CGameData.CGame> games)
+        {
+            // Log the platforms
+            Log(string.Format("Found {0} platforms and {1} games:", platforms.Keys.Count, platforms.Values.Count));
+            foreach(KeyValuePair<string, int> platform in platforms)
+            {
+                Log(string.Format("Platform: {0} -> {1} games", platform.Key, platform.Value));
+            }
+            Log("");
+            // Log the actual games
+            foreach(CGameData.CGame game in games)
+            {
+                Log(string.Format("ID: {0}, Title: {1}, Platform: {2}", game.ID, game.Title, game.PlatformString));
+                Log(string.Format("Alias: {0}, Frequency: {1}", game.Alias, game.Frequency));
+                Log(string.Format("Launch: {0}, Uninstall: {1}, Icon {2}", game.Launch, game.Uninstaller, game.Icon));
+                Log(string.Format("Favourite: {0}, Hidden: {1}", game.IsFavourite, game.IsHidden));
+                Log("");
+            }
+        }
+    }
+}

--- a/GameLauncher_Console/DataConversionTool/InputOutput.cs
+++ b/GameLauncher_Console/DataConversionTool/InputOutput.cs
@@ -5,11 +5,11 @@ using System.Collections.Generic;
 
 namespace DataConversionTool
 {
-    public class CInputOutput
+    public static class CInputOutput
     {
         // Command-line option const
-        private const string FLAG_APPLY = "apply";
-        private const string FLAG_VERIFY = "verify";
+        private const string FLAG_APPLY = "-apply";
+        private const string FLAG_VERIFY = "-verify";
 
         private static readonly string[] HELP =
         {
@@ -20,27 +20,25 @@ namespace DataConversionTool
             "-apply: Perform the same checks as 'verify' and also migrate data to the DB",
         };
 
-        public CInputOutput()
-        {
-
-        }
-
         /// <summary>
         /// Determine tool mode from input string
         /// </summary>
         /// <param name="mode">Input string</param>
         /// <returns>ConvertMode enum</returns>
-        public CConverter.ConvertMode DetermineMode(string mode)
+        public static CConverter.ConvertMode DetermineMode(string mode)
         {
             switch(mode)
             {
                 case FLAG_VERIFY:
+                    Log("Running in VERIFY mode");
                     return CConverter.ConvertMode.cModeVerify;
                         
                 case FLAG_APPLY:
+                    Log("Running in APPLY mode");
                     return CConverter.ConvertMode.cModeApply;
 
                 default:
+                    Log("WARN: Could not determine mode");
                     return CConverter.ConvertMode.cModeUnknown;
             }
         }
@@ -48,7 +46,7 @@ namespace DataConversionTool
         /// <summary>
         /// Write help array to donsole
         /// </summary>
-        public void ShowHelp()
+        public static void ShowHelp()
         {
             Console.Clear();
             foreach(string s in HELP)

--- a/GameLauncher_Console/DataConversionTool/Program.cs
+++ b/GameLauncher_Console/DataConversionTool/Program.cs
@@ -1,0 +1,25 @@
+﻿using Logger;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace DataConversionTool
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+#if DEBUG
+            // Log unhandled exceptions
+            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CLogger.ExceptionHandleEvent);
+#endif
+            CLogger.Configure(Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]) + ".log"); // Create a log file
+            CLogger.LogInfo("{0} version {1}",
+                Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyTitleAttribute>().Title,
+                Assembly.GetEntryAssembly().GetName().Version.ToString());
+            CLogger.LogInfo("*************************");
+        }
+
+
+    }
+}

--- a/GameLauncher_Console/DataConversionTool/Program.cs
+++ b/GameLauncher_Console/DataConversionTool/Program.cs
@@ -18,8 +18,20 @@ namespace DataConversionTool
                 Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyTitleAttribute>().Title,
                 Assembly.GetEntryAssembly().GetName().Version.ToString());
             CLogger.LogInfo("*************************");
+
+           if(args.Length == 0)
+            {
+                CInputOutput.Log("No arguments provided");
+                CInputOutput.ShowHelp();
+                return;
+            }
+            CConverter.ConvertMode mode = CInputOutput.DetermineMode(args[0]);
+            if(mode == CConverter.ConvertMode.cModeUnknown)
+            {
+                return;
+            }
+            CConverter converter = new CConverter(mode);
+            converter.ConvertData();
         }
-
-
     }
 }

--- a/GameLauncher_Console/DataConversionTool/Properties/AssemblyInfo.cs
+++ b/GameLauncher_Console/DataConversionTool/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DataConversionTool")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DataConversionTool")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("92a97d68-92b7-4348-9275-bc3e9d0e8941")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GameLauncher_Console/DataConversionTool/packages.config
+++ b/GameLauncher_Console/DataConversionTool/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.3.0" targetFramework="net472" />
+  <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.113.3" targetFramework="net472" />
+  <package id="System.Data.SQLite" version="1.0.113.7" targetFramework="net472" />
+  <package id="System.Data.SQLite.Core" version="1.0.113.7" targetFramework="net472" />
+  <package id="System.Data.SQLite.EF6" version="1.0.113.0" targetFramework="net472" />
+  <package id="System.Data.SQLite.Linq" version="1.0.113.0" targetFramework="net472" />
+</packages>

--- a/GameLauncher_Console/GameLauncher_Console.sln
+++ b/GameLauncher_Console/GameLauncher_Console.sln
@@ -8,6 +8,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTest", "UnitTest\UnitTest.csproj", "{FBEDF6E1-33EC-4B48-B44F-0CC2CE8585BF}"
 	ProjectSection(ProjectDependencies) = postProject
 		{4EBCEF5B-1A8A-42FB-81DB-446A14ED15D1} = {4EBCEF5B-1A8A-42FB-81DB-446A14ED15D1}
+		{92A97D68-92B7-4348-9275-BC3E9D0E8941} = {92A97D68-92B7-4348-9275-BC3E9D0E8941}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataConversionTool", "DataConversionTool\DataConversionTool.csproj", "{92A97D68-92B7-4348-9275-BC3E9D0E8941}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4EBCEF5B-1A8A-42FB-81DB-446A14ED15D1} = {4EBCEF5B-1A8A-42FB-81DB-446A14ED15D1}
 	EndProjectSection
 EndProject
 Global
@@ -24,6 +30,10 @@ Global
 		{FBEDF6E1-33EC-4B48-B44F-0CC2CE8585BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBEDF6E1-33EC-4B48-B44F-0CC2CE8585BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBEDF6E1-33EC-4B48-B44F-0CC2CE8585BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92A97D68-92B7-4348-9275-BC3E9D0E8941}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92A97D68-92B7-4348-9275-BC3E9D0E8941}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92A97D68-92B7-4348-9275-BC3E9D0E8941}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92A97D68-92B7-4348-9275-BC3E9D0E8941}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GameLauncher_Console/GameLauncher_Console/Database/CreateDB.sql
+++ b/GameLauncher_Console/GameLauncher_Console/Database/CreateDB.sql
@@ -1,6 +1,7 @@
 -- Create tables --
 
 CREATE TABLE "SystemAttribute" (
+	"SystemFK"			INTEGER,
 	"AttributeName"		varchar(50),
 	"AttributeIndex"	INTEGER,
 	"AttributeValue"	varchar(255)

--- a/GameLauncher_Console/GameLauncher_Console/Database/CreateDB.sql
+++ b/GameLauncher_Console/GameLauncher_Console/Database/CreateDB.sql
@@ -26,6 +26,7 @@ CREATE TABLE "Game" (
 	"IsHidden"		bit NOT NULL DEFAULT 0,
 	"Frequency"		NUMERIC NOT NULL DEFAULT 0.0,
 	"Rating"		INTEGER,
+	"Icon" 			VARCHAR(255),
 	"Description" 	VARCHAR(255),
 	"IsMultiPlatform" bit NOT NULL DEFAULT 0,
 	PRIMARY KEY("GameID" AUTOINCREMENT),

--- a/GameLauncher_Console/GameLauncher_Console/Extensions.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Extensions.cs
@@ -1,9 +1,14 @@
-﻿using System.Collections.Generic;
+﻿using Logger;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using System.Text;
 
 namespace GameLauncher_Console
 {
 	/// <summary>
-	/// Collection of extension methods
+	/// class for extension and helper methods
 	/// </summary>
 	public static class CExtensions
 	{
@@ -18,5 +23,85 @@ namespace GameLauncher_Console
 		{
 			return new HashSet<T>(source, comparer);
 		}
-	}
+
+        /// <summary>
+        /// StringBuilder extension method
+        /// Returns the index of the start of the contents in a StringBuilder
+        /// </summary>        
+        /// <param name="value">The string to find</param>
+        /// <param name="startIndex">The starting index.</param>
+        /// <param name="ignoreCase">if set totrue it will ignore case</param>
+        /// <returns></returns>
+        public static int IndexOf(this StringBuilder sb, string value, int startIndex, bool ignoreCase)
+        {
+            int index;
+            int length = value.Length;
+            int maxSearchLength = (sb.Length - length) + 1;
+
+            if (ignoreCase)
+            {
+                for (int i = startIndex; i < maxSearchLength; ++i)
+                {
+                    if (Char.ToLower(sb[i]) == Char.ToLower(value[0]))
+                    {
+                        index = 1;
+                        while ((index < length) && (Char.ToLower(sb[i + index]) == Char.ToLower(value[index])))
+                        {
+                            ++index;
+                        }
+                        if (index == length)
+                        {
+                            return i;
+                        }
+                    }
+                }
+                return -1;
+            }
+
+            for (int i = startIndex; i < maxSearchLength; ++i)
+            {
+                if (sb[i] == value[0])
+                {
+                    index = 1;
+                    while ((index < length) && (sb[i + index] == value[index]))
+                    {
+                        ++index;
+                    }
+
+                    if (index == length)
+                    {
+                        return i;
+                    }
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Get enum description
+        /// </summary>
+        /// <returns>description string</returns>
+        /// <param name="enum">Enum</param>
+        public static string GetDescription<T>(this T source)
+        {
+            try
+            {
+                FieldInfo field = source.GetType().GetField(source.ToString());
+
+                DescriptionAttribute[] attr = (DescriptionAttribute[])field.GetCustomAttributes(
+                    typeof(DescriptionAttribute), false);
+
+                if (attr != null && attr.Length > 0) return attr[0].Description;
+            }
+            catch (Exception e)
+            {
+                CLogger.LogError(e);
+            }
+            Type type = source.GetType();
+            string output = type.GetEnumName(source);
+            if (!string.IsNullOrEmpty(output))
+                return output;
+            return source.ToString();
+        }
+    }
 }

--- a/GameLauncher_Console/GameLauncher_Console/Game.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Game.cs
@@ -1,5 +1,8 @@
-﻿using SqlDB;
+﻿using GameLauncher_Console;
+using SqlDB;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.SQLite;
 using System.Linq;
 using static SqlDB.CSqlField;
@@ -33,75 +36,31 @@ namespace CGame_Test // TODO: GameLauncher_Console
 			*/
         };
 
-        private static CQryGame m_qryGame = new CQryGame();
-        private static CDbAttribute m_gameAttribute = new CDbAttribute("Game");
-        private static GameSet m_currentGames = new GameSet();
-
-        /// <summary>
-        /// Dictionary collection implementation for the game object
-        /// Encapsulates all sorting and direct manipulation of the collection
-        /// </summary>
-        public class GameSet : Dictionary<string, GameObject>
-        {
-            /// <summary>
-            /// Enum used when returning sorted lists of games
-            /// The flags can be added together to support multi-parameter sorting
-            /// The lower flag values take precedence as they are easier to sort
-            /// Performance should be considered before sorting with all flags
-            /// </summary>
-            public enum SortFlag
-            {
-                // When adding new sorting flags, add the easiest ones (such as binary flags)
-                // to the top and more difficult ones (alphabetical) to the bottom.
-                cSortFavourite  = 0x01,
-                cSortFrequency  = 0x02,
-                cSortRating     = 0x04,
-                cSortAlpha      = 0x08,
-            }
-
-            public GameSet()
-            {
-
-            }
-
-            /// <summary>
-            /// The current platform of the games
-            /// </summary>
-            public int Platform { get; set; }
-
-            /// <summary>
-            /// Sort the current GameSet
-            /// </summary>
-            /// <param name="flag">Sorting flags</param>
-            /// <param name="noArticle">If true and doing alpha sort, ignore articles in the names</param>
-            /// <returns>List of sorted games</returns>
-            public List<GameObject> SortGames(SortFlag flag, bool noArticle)
-            {
-                return null; // TODO
-            }
-        }
+        // Due to C#'s limitations, every query will come with a lot of bloated boilerplate code
+        // Best thing to do for now is to hide them away in a region and just use them. I will have to return to them one day
+        #region Query definitions
 
         /// <summary>
         /// Main game query, handling all reading and writing
         /// TODO: Once the game class is done, it's probably worth seeing if this can be split into special-purpose queries to improve performance and avoid potential problems
         /// </summary>
         public class CQryGame : CSqlQry
-        { 
+        {
             public CQryGame() : base("Game", "", "")
             {
-                m_sqlRow["GameID"]          = new CSqlFieldInteger("GameID",          QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
-                m_sqlRow["PlatformFK"]      = new CSqlFieldInteger("PlatformFK",      QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
-                m_sqlRow["Identifier"]      = new CSqlFieldString("Identifier",       QryFlag.cInsWrite | QryFlag.cSelRead );
-                m_sqlRow["Title"]           = new CSqlFieldString("Title",            QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["Alias"]           = new CSqlFieldString("Alias",            QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["Launch"]          = new CSqlFieldString("Launch",           QryFlag.cInsWrite | QryFlag.cSelRead );
-                m_sqlRow["Uninstall"]       = new CSqlFieldString("Uninstall",        QryFlag.cInsWrite | QryFlag.cSelRead );
-                m_sqlRow["IsFavourite"]     = new CSqlFieldBoolean("IsFavourite",     QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["IsHidden"]        = new CSqlFieldBoolean("IsHidden",        QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["Frequency"]       = new CSqlFieldDouble("Frequency",        QryFlag.cInsWrite | QryFlag.cSelRead );
-                m_sqlRow["Rating"]          = new CSqlFieldInteger("Rating",          QryFlag.cInsWrite | QryFlag.cSelRead );
-                m_sqlRow["Icon"]            = new CSqlFieldString("Description",      QryFlag.cInsWrite | QryFlag.cSelRead );
-                m_sqlRow["Description"]     = new CSqlFieldString("Description",      QryFlag.cInsWrite | QryFlag.cSelRead );
+                m_sqlRow["GameID"]          = new CSqlFieldInteger("GameID", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
+                m_sqlRow["PlatformFK"]      = new CSqlFieldInteger("PlatformFK", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
+                m_sqlRow["Identifier"]      = new CSqlFieldString("Identifier", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Title"]           = new CSqlFieldString("Title", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Alias"]           = new CSqlFieldString("Alias", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Launch"]          = new CSqlFieldString("Launch", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Uninstall"]       = new CSqlFieldString("Uninstall", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["IsFavourite"]     = new CSqlFieldBoolean("IsFavourite", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["IsHidden"]        = new CSqlFieldBoolean("IsHidden", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Frequency"]       = new CSqlFieldDouble("Frequency", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Rating"]          = new CSqlFieldInteger("Rating", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Icon"]            = new CSqlFieldString("Description", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Description"]     = new CSqlFieldString("Description", QryFlag.cInsWrite | QryFlag.cSelRead);
                 m_sqlRow["IsMultiPlatform"] = new CSqlFieldBoolean("IsMultiPlatform", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
             }
             public int GameID
@@ -177,6 +136,152 @@ namespace CGame_Test // TODO: GameLauncher_Console
         }
 
         /// <summary>
+        /// Query for game sorting
+        /// </summary>
+        private class CQryGameSort : CSqlQry
+        {
+            public CQryGameSort() : base("Game", "", "")
+            {
+                m_sqlRow["GameID"] = new CSqlFieldInteger("GameID", QryFlag.cSelRead);
+                m_sqlRow["PlatformFK"] = new CSqlFieldInteger("PlatformFK", QryFlag.cSelWhere);
+            }
+
+            public int GameID
+            {
+                get { return m_sqlRow["GameID"].Integer; }
+                set { m_sqlRow["GameID"].Integer = value; }
+            }
+            public int PlatformFK
+            {
+                get { return m_sqlRow["PlatformFK"].Integer; }
+                set { m_sqlRow["PlatformFK"].Integer = value; }
+            }
+        }
+
+        /// <summary>
+        /// Class for performing a fuzzy search 
+        /// </summary>
+        private class CQryGameFuzzySearch : CSqlQry
+        {
+            public CQryGameFuzzySearch() : base("Game", "(& = ?) AND (& LIKE '%?%')", "")
+            {
+                m_sqlRow["PlatformFK"] = new CSqlFieldInteger("PlatformFK", QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Title"] = new CSqlFieldString("Title", QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["GameID"] = new CSqlFieldInteger("GameID", QryFlag.cSelRead);
+            }
+            public int GameID
+            {
+                get { return m_sqlRow["GameID"].Integer; }
+                set { m_sqlRow["GameID"].Integer = value; }
+            }
+            public int PlatformFK
+            {
+                get { return m_sqlRow["PlatformFK"].Integer; }
+                set { m_sqlRow["PlatformFK"].Integer = value; }
+            }
+            public string Title
+            {
+                get { return m_sqlRow["Title"].String; }
+                set { m_sqlRow["Title"].String = value; }
+            }
+        }
+        
+        #endregion // Query definitions
+
+        private static CQryGame m_qryGame = new CQryGame();
+        private static CDbAttribute m_gameAttribute = new CDbAttribute("Game");
+        private static GameSet m_currentGames = new GameSet();
+
+        /// <summary>
+        /// Dictionary collection implementation for the game object
+        /// Encapsulates all sorting and direct manipulation of the collection
+        /// </summary>
+        public class GameSet : Dictionary<string, GameObject>
+        {
+            /// <summary>
+            /// Enum used when returning sorted lists of games
+            /// The flags can be added together to support multi-parameter sorting
+            /// The lower flag values take precedence as they are easier to sort
+            /// Performance should be considered before sorting with all flags
+            /// </summary>
+            public enum SortFlag
+            {
+                // When adding new sorting flags, add the easiest ones (such as binary flags)
+                // to the top and more difficult ones (alphabetical) to the bottom.
+                [Description("IsFavourite")]
+                cSortFavourite  = 0x01,
+                [Description("Frequency")]
+                cSortFrequency  = 0x02,
+                [Description("Rating")]
+                cSortRating     = 0x04,
+                [Description("Title")]
+                cSortAlpha      = 0x08,
+            }
+
+            private CQryGameSort m_qryGameSort;
+
+            public GameSet()
+            {
+                m_qryGameSort = new CQryGameSort();
+            }
+
+            /// <summary>
+            /// The current platform of the games
+            /// </summary>
+            public int Platform { get; set; }
+
+            /// <summary>
+            /// Sort the current GameSet
+            /// </summary>
+            /// <param name="flag">Sorting flags</param>
+            /// <param name="ascending">If true, sort by ascending order, otherwise sort by descending</param>
+            /// <param name="noArticle">If true and doing alpha sort, ignore articles in the names</param>
+            /// <returns>List of sorted games</returns>
+            public List<int> SortGames(SortFlag flag, bool ascending, bool noArticle)
+            {
+                // TODO. all, fav, hidden games
+                // TODO. ignore article
+                List<int> outGameIDs = new List<int>();
+
+                m_qryGameSort.MakeFieldsNull();
+                m_qryGameSort.PlatformFK = Platform; // Using current platform
+
+                // Create the order by condition
+                string orderByString = " ORDER BY ";
+                int used = 0;
+                foreach(SortFlag i in Enum.GetValues(typeof(SortFlag)))
+                {
+                    if((flag & i) > 0)
+                    {
+                        orderByString += CExtensions.GetDescription(i);
+                        if(!ascending)
+                        {
+                            orderByString += " DESC, ";
+                        }
+                        used++;
+                    }
+                }
+                if(used == 1) // Remove tailing comma
+                {
+                    orderByString.Remove(',');
+                }
+                else if(used == 0) // Clear if no flags (just in case)
+                {
+                    orderByString = "";
+                }
+                m_qryGameSort.SelectExtraCondition = orderByString;
+                if (m_qryGameSort.Select() == SQLiteErrorCode.Ok)
+                {
+                    do
+                    {
+                        outGameIDs.Add(m_qryGameSort.GameID);
+                    } while (m_qryGameSort.Fetch());
+                }
+                return outGameIDs;
+            }
+        }
+
+        /// <summary>
         /// Struct which actually holds the game information
         /// </summary>
         public struct GameObject
@@ -245,41 +350,25 @@ namespace CGame_Test // TODO: GameLauncher_Console
             public double Rating        { get; set; }
             public double Frequency     { get; private set; }
             public bool IsMultiPlatform { get; set; }
-            /*
+
             /// <summary>
             /// Equals override for HashSet comparison.
             /// </summary>
             /// <param name="other">Object to compare against</param>
-            /// <returns>True if other is <c>GameObject</c> and the titles are matching</returns>
+            /// <returns>True is other is not null and the titles are matching</returns>
             public override bool Equals(object other)
             {
-                return (other is GameObject game && Title == game.Title);
+                // We're only interested in comparing the titles
+                return (other is GameObject game && this.Title == game.Title);
             }
 
             /// <summary>
-            /// Return the hashcode of the games's title
+            /// Return the hash code of this object's title variable
             /// </summary>
             /// <returns>Hash code</returns>
             public override int GetHashCode()
             {
-                return Title.GetHashCode();
-            }
-            */
-            /// <summary>
-            /// Increment game's frequency by 5
-            /// </summary>
-            public void IncrementFrequency()
-            {
-                Frequency += 5;
-            }
-
-            /// <summary>
-            /// Decrement the game's frequency by 10% and truncate to 3dp.
-            /// </summary>
-            public void DecimateFrequency()
-            {
-                Frequency -= (Frequency / 10);
-                Frequency = ((int)(Frequency * 1000)) / 1000; // TODO verify
+                return this.Title.GetHashCode();
             }
         }
 
@@ -310,6 +399,20 @@ namespace CGame_Test // TODO: GameLauncher_Console
                 } while(m_qryGame.Fetch());
             }
             return m_currentGames.Values.ToList();
+        }
+
+        public static HashSet<GameObject> GetAllGames()
+        {
+            HashSet<GameObject> outHashSet = new HashSet<GameObject>();
+            m_qryGame.MakeFieldsNull();
+            if(m_qryGame.Select() == SQLiteErrorCode.Ok)
+            {
+                do
+                {
+                    outHashSet.Add(new GameObject(m_qryGame));
+                } while(m_qryGame.Fetch());
+            }
+            return outHashSet;
         }
 
         /// <summary>
@@ -402,7 +505,22 @@ namespace CGame_Test // TODO: GameLauncher_Console
         /// <param name="games">Game set to merge</param>
         public static void MergeGameSets(GameSet games)
         {
+            HashSet<GameObject> newGames = games.Values.ToHashSet();
+            HashSet<GameObject> allGames = GetAllGames().ToHashSet();
 
+            HashSet<GameObject> toAdd = new HashSet<GameObject>(newGames);
+            toAdd.ExceptWith(allGames);
+            HashSet<GameObject> toRemove = new HashSet<GameObject>(allGames);
+            toRemove.ExceptWith(newGames);
+
+            foreach(GameObject game in toAdd)
+            {
+                InsertGame(game);
+            }
+            foreach(GameObject game in toRemove)
+            {
+                RemoveGame(game.GameID);
+            }
         }
 
         /// <summary>
@@ -413,8 +531,7 @@ namespace CGame_Test // TODO: GameLauncher_Console
         /// <param name="gameID">gameID of the game to increment</param>
         public static void NormaliseFrequencies(int gameID)
         {
-            // TODO:
-            // Instead of updating each game separately, write a query that does it for us
+            CSqlDB.Instance.Execute("UPDATE Game SET Frequency = (CASE GameID WHEN " + gameID + " THEN Frequency + 5 ELSE Frequency * 0.9 END)");
         }
 
         /// <summary>

--- a/GameLauncher_Console/GameLauncher_Console/Game.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Game.cs
@@ -48,19 +48,19 @@ namespace CGame_Test // TODO: GameLauncher_Console
         {
             public CQryGame() : base("Game", "", "")
             {
-                m_sqlRow["GameID"]          = new CSqlFieldInteger("GameID", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
-                m_sqlRow["PlatformFK"]      = new CSqlFieldInteger("PlatformFK", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
-                m_sqlRow["Identifier"]      = new CSqlFieldString("Identifier", QryFlag.cInsWrite | QryFlag.cSelRead);
-                m_sqlRow["Title"]           = new CSqlFieldString("Title", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["Alias"]           = new CSqlFieldString("Alias", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["Launch"]          = new CSqlFieldString("Launch", QryFlag.cInsWrite | QryFlag.cSelRead);
-                m_sqlRow["Uninstall"]       = new CSqlFieldString("Uninstall", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["GameID"]          = new CSqlFieldInteger("GameID"     , QryFlag.cSelRead | QryFlag.cWhere);
+                m_sqlRow["PlatformFK"]      = new CSqlFieldInteger("PlatformFK" , QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cWhere);
+                m_sqlRow["Identifier"]      = new CSqlFieldString("Identifier"  , QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Title"]           = new CSqlFieldString("Title"       , QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Alias"]           = new CSqlFieldString("Alias"       , QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Launch"]          = new CSqlFieldString("Launch"      , QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Uninstall"]       = new CSqlFieldString("Uninstall"   , QryFlag.cInsWrite | QryFlag.cSelRead);
                 m_sqlRow["IsFavourite"]     = new CSqlFieldBoolean("IsFavourite", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["IsHidden"]        = new CSqlFieldBoolean("IsHidden", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
-                m_sqlRow["Frequency"]       = new CSqlFieldDouble("Frequency", QryFlag.cInsWrite | QryFlag.cSelRead);
-                m_sqlRow["Rating"]          = new CSqlFieldInteger("Rating", QryFlag.cInsWrite | QryFlag.cSelRead);
-                m_sqlRow["Icon"]            = new CSqlFieldString("Description", QryFlag.cInsWrite | QryFlag.cSelRead);
-                m_sqlRow["Description"]     = new CSqlFieldString("Description", QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["IsHidden"]        = new CSqlFieldBoolean("IsHidden"   , QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
+                m_sqlRow["Frequency"]       = new CSqlFieldDouble("Frequency"   , QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Rating"]          = new CSqlFieldInteger("Rating"     , QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Icon"]            = new CSqlFieldString("Icon"        , QryFlag.cInsWrite | QryFlag.cSelRead);
+                m_sqlRow["Description"]     = new CSqlFieldString("Description" , QryFlag.cInsWrite | QryFlag.cSelRead);
                 m_sqlRow["IsMultiPlatform"] = new CSqlFieldBoolean("IsMultiPlatform", QryFlag.cInsWrite | QryFlag.cSelRead | QryFlag.cSelWhere);
             }
             public int GameID
@@ -315,19 +315,20 @@ namespace CGame_Test // TODO: GameLauncher_Console
             /// <param name="platformFK">PlatformFK database field</param>
             /// <param name="identifier">Identifier used for launching the game (eg. steamapp id)</param>
             /// <param name="title">Game title</param>
+            /// <param name="alias">Game alias</param>
             /// <param name="launch">Game executable path or launch string</param>
             /// <param name="uninstall">Game uninstaller path or uninstall string</param>
-            public GameObject(int platformFK, string identifier, string title, string launch, string uninstall)
+            public GameObject(int platformFK, string identifier, string title, string alias, string launch, string uninstall)
             {
                 PlatformFK  = platformFK;
                 Identifier  = identifier;
                 Title       = title;
+                Alias       = alias;
                 Launch      = launch;
                 Uninstall   = uninstall;
 
                 // Default rest
                 GameID          = 0;
-                Alias           = "";
                 Icon            = "";
                 IsFavourite     = false;
                 IsHidden        = false;
@@ -423,9 +424,13 @@ namespace CGame_Test // TODO: GameLauncher_Console
         public static bool InsertGame(GameObject game)
         {
             m_qryGame.MakeFieldsNull();
-            m_qryGame.PlatformFK = game.PlatformFK;
+            if(game.PlatformFK > 0)
+            {
+                m_qryGame.PlatformFK = game.PlatformFK;
+            }
             m_qryGame.Identifier = game.Identifier;
             m_qryGame.Title      = game.Title;
+            m_qryGame.Alias      = (game.Alias.Length > 0) ? game.Alias : game.Title;
             m_qryGame.Launch     = game.Launch;
             m_qryGame.Uninstall  = game.Uninstall;
             if(m_qryGame.Insert() == SQLiteErrorCode.Ok)

--- a/GameLauncher_Console/GameLauncher_Console/Game.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Game.cs
@@ -1,0 +1,85 @@
+﻿
+
+namespace GameLauncher_Console
+{
+    /// <summary>
+    /// Handles any game-relaed logic and data structures
+    /// </summary>
+    public static class CGame
+    {
+        /// <summary>
+        /// Game title articles.
+        /// Removed from titles when creating default aliases
+        /// Ignored during title searches
+        /// </summary>
+        public static readonly string[] ARTICLES =
+        {
+            "The ",								// English definite
+			"A ", "An ",						// English indefinite
+			/*
+			"El ", "La ", "Los ", "Las ",		// Spanish definite
+			"Un ", "Una ", "Unos ", "Unas ",	// Spanish indefinite
+			"Le ", "Les ", "L\'",				//, "La" [Spanish] // French definite
+			"Une ", "De ", "Des ",				//, "Un" [Spanish] // French indefinite [many French sort with indefinite article]
+			"Der", "Das",						//, "Die" [English word] // German definite
+			"Ein", "Eine"						// German indefinite
+			*/
+        };
+
+        /// <summary>
+        /// Main game query, handling all reading and writing
+        /// TODO: Once the game class is done, it's probably worth seeing if this can be split into special-purpose queries to improve performance and avoid potential problems
+        /// </summary>
+        /*
+        private class CQryGame : CSqlQry
+        { 
+            public CQryGame() : base("Game")
+            {
+                m_fields["GameID"]          = new CSqlFieldInteger("GameID",          CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cWhere);
+                m_fields["PlatformFK"]      = new CSqlFieldInteger("PlatformFK",      CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cWhere);
+                m_fields["Identifier"]      = new CSqlFieldString("Identifier",       CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead);
+                m_fields["Title"]           = new CSqlFieldString("Title",            CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cSelWhere);
+                m_fields["Alias"]           = new CSqlFieldString("Alias",            CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cSelWhere);
+                m_fields["Launch"]          = new CSqlFieldString("Launch",           CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead);
+                m_fields["Uninstall"]       = new CSqlFieldString("Uninstall",        CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead);
+                m_fields["IsFavourite"]     = new CSqlFieldBoolean("IsFavourite",     CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cSelWhere);
+                m_fields["IsHidden"]        = new CSqlFieldBoolean("IsHidden",        CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cSelWhere);
+                m_fields["Frequency"]       = new CSqlFieldDouble("Frequency",        CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead);
+                m_fields["Rating"]          = new CSqlFieldInteger("Rating",          CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead);
+                m_fields["Description"]     = new CSqlFieldString("Description",      CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead);
+                m_fields["IsMultiPlatform"] = new CSqlFieldBoolean("IsMultiPlatform", CSqlField.QryFlag.cInsWrite | CSqlField.QryFlag.cSelRead | CSqlField.QryFlag.cSelWhere);
+            }
+
+            public string this[string key]
+            {
+                get { return m_fields[key].String; }
+                set { m_fields[key].String = value; }
+            }
+        }
+        */
+
+        /// <summary>
+        /// Struct which actually holds the game information
+        /// </summary>
+        public struct GameObject
+        {
+            // TODOs:
+            //  once platform enum is implemented, change platofmr type from int to Platform
+
+            //private readonly Platform m_platformID;
+            private readonly int m_platformID;
+
+            public string ID { get; private set; }
+            public string Title { get; private set; }
+            public string Launch { get; private set; }
+            public string Uninstall { get; private set; }
+            public string Icon { get; private set; }
+            public bool IsFavourite { get; private set; }
+            public bool IsHidden { get; private set; }
+            public double OccurCount { get; private set; }
+
+            //public Platform PlatformID { get; }
+            public int PlatformID { get; }
+        }
+    }
+}

--- a/GameLauncher_Console/GameLauncher_Console/GameLauncher_Console.csproj
+++ b/GameLauncher_Console/GameLauncher_Console/GameLauncher_Console.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Game.cs" />
     <Compile Include="GameData.cs" />
     <Compile Include="GameFinder.cs" />
+    <Compile Include="Platform.cs" />
     <Compile Include="SqlDB.cs" />
     <Compile Include="SteamWrapper.cs" />
     <Compile Include="JsonWrapper.cs" />

--- a/GameLauncher_Console/GameLauncher_Console/GameLauncher_Console.csproj
+++ b/GameLauncher_Console/GameLauncher_Console/GameLauncher_Console.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Dock.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="Game.cs" />
     <Compile Include="GameData.cs" />
     <Compile Include="GameFinder.cs" />
     <Compile Include="SqlDB.cs" />

--- a/GameLauncher_Console/GameLauncher_Console/Platform.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Platform.cs
@@ -1,0 +1,224 @@
+﻿using SqlDB;
+using System.Collections.Generic;
+using System.ComponentModel;
+using static SqlDB.CSqlField;
+using System.Data.SQLite;
+
+namespace GameLauncher_Console
+{
+	/// <summary>
+	/// Class to handle platform object and platform database table
+	/// </summary>
+    public static class CPlatform
+    {
+		/// <summary>
+		/// Enumerator containing currently supported game platforms
+		/// </summary>
+		public enum GamePlatform
+        {
+			[Description("Unknown")]
+			Unknown = -1,
+			[Description("Favourites")]
+			Favourites = 0,
+			[Description("Custom games")]
+			Custom = 1,
+			[Description("All games")]
+			All = 2,
+			[Description("Steam")]
+			Steam = 3,
+			[Description("GOG Galaxy")]
+			GOG = 4,
+			[Description("Ubisoft Connect")]
+			Uplay = 5,
+			[Description("Origin")]
+			Origin = 6,
+			[Description("Epic")]
+			Epic = 7,
+			[Description("Betheda.net")]
+			Bethesda = 8,
+			[Description("Battle.net")]
+			Battlenet = 9,
+			[Description("Rockstar")]
+			Rockstar = 10,
+			[Description("Hidden games")]
+			Hidden = 11,
+			[Description("Search results")]
+			Search = 12,
+			[Description("Amazon")]
+			Amazon = 13,
+			[Description("Big Fish")]
+			BigFish = 14,
+			[Description("Arc")]
+			Arc = 15,
+			[Description("itch")]
+			Itch = 16,
+			[Description("Paradox")]
+			Paradox = 17,
+			[Description("Plarium Play")]
+			Plarium = 18,
+			[Description("Twitch")]
+			Twitch = 19,
+			[Description("Wargaming.net")]
+			Wargaming = 20
+		}
+
+		#region Query definitions
+
+		/// <summary>
+		/// Retrieve the platform information fromthe database
+		/// Also returns the game count for each platform
+		/// </summary>
+		public class CQryReadPlatforms : CSqlQry
+        {
+			public CQryReadPlatforms()
+				: base(
+				"Platform " + 
+				"LEFT JOIN Game G on PlatformID = G.PlatformFK", 
+				"", " GROUP BY PlatformID")
+			{
+				m_sqlRow["PlatformID"]	= new CSqlFieldInteger("PlatformID", QryFlag.cSelWhere);
+				m_sqlRow["Name"]		= new CSqlFieldString("Name",		 QryFlag.cSelRead);
+				m_sqlRow["GameCount"]	= new CSqlFieldString("COUNT(G.GameID) as GameCount", QryFlag.cSelRead);
+			}
+			public int PlatformID
+			{
+				get { return m_sqlRow["PlatformID"].Integer; }
+				set { m_sqlRow["PlatformID"].Integer = value; }
+			}
+			public string Name
+			{
+				get { return m_sqlRow["Name"].String; }
+				set { m_sqlRow["Name"].String = value; }
+			}
+			public int GameCount
+			{
+				get { return m_sqlRow["GameCount"].Integer; }
+				set { m_sqlRow["GameCount"].Integer = value; }
+			}
+		}
+
+		/// <summary>
+		/// Query for writing to the platform table
+		/// </summary>
+		public class CQryWritePlatforms : CSqlQry
+        {
+			public CQryWritePlatforms()
+				: base("Platform", "", "")
+			{
+				m_sqlRow["PlatformID"]	= new CSqlFieldInteger("PlatformID" , QryFlag.cUpdWhere | QryFlag.cDelWhere);
+				m_sqlRow["Name"]		= new CSqlFieldString("Name"		, QryFlag.cUpdWrite | QryFlag.cInsWrite);
+				m_sqlRow["Description"]	= new CSqlFieldString("Description" , QryFlag.cUpdWrite | QryFlag.cInsWrite);
+			}
+			public int PlatformID
+			{
+				get { return m_sqlRow["PlatformID"].Integer; }
+				set { m_sqlRow["PlatformID"].Integer = value; }
+			}
+			public string Name
+			{
+				get { return m_sqlRow["Name"].String; }
+				set { m_sqlRow["Name"].String = value; }
+			}
+			public string Description
+			{
+				get { return m_sqlRow["Description"].String; }
+				set { m_sqlRow["Description"].String = value; }
+			}
+		}
+
+		#endregion // Query definitions
+
+		private static CQryReadPlatforms m_qryRead = new CQryReadPlatforms();
+		private static CQryWritePlatforms m_qryWrite = new CQryWritePlatforms();
+
+		/// <summary>
+		/// Container for a single platform
+		/// </summary>
+		public struct PlatformObject
+        {
+			public PlatformObject(int platformID, string name, int gameCount, string description)
+            {
+				PlatformID	= platformID;
+				Name		= name;
+				GameCount	= gameCount;
+				Description = description;
+			}
+
+			/// <summary>
+			/// Constructor overload.
+			/// Populate using query
+			/// </summary>
+			/// <param name="qryRead"></param>
+			public PlatformObject(CQryReadPlatforms qryRead)
+			{
+				PlatformID	= qryRead.PlatformID;
+				Name		= qryRead.Name;
+				GameCount	= qryRead.GameCount;
+				Description = "";
+			}
+
+			// Properties
+			public int PlatformID { get; }
+			public string Name { get; }
+			public int GameCount { get; private set; }
+			public string Description { get; }
+        }
+
+		/// <summary>
+		/// Get list of platforms from the database
+		/// </summary>
+		/// <returns>List of PlatformObjects</returns>
+		public static List<PlatformObject> GetPlatforms()
+        {
+			List<PlatformObject> platforms = new List<PlatformObject>();
+			m_qryRead.MakeFieldsNull();
+			if(m_qryRead.Select() == SQLiteErrorCode.Ok)
+            {
+				do
+				{
+					platforms.Add(new PlatformObject(m_qryRead));
+				} while(m_qryRead.Fetch());
+            }
+			return platforms;
+        }
+
+		/// <summary>
+		/// Insert specified platform into the database
+		/// </summary>
+		/// <param name="platform">The PlatformObject to insert</param>
+		/// <returns>True on insert success, otherwise false</returns>
+		public static bool InsertPlatform(PlatformObject platform)
+        {
+			m_qryWrite.MakeFieldsNull();
+			m_qryWrite.Name			= platform.Name;
+			m_qryWrite.Description	= platform.Description;
+			return m_qryWrite.Insert() == SQLiteErrorCode.Ok;
+        }
+
+		/// <summary>
+		/// Update specified platform
+		/// </summary>
+		/// <param name="platform">The PlatformObject to write</param>
+		/// <returns>True on update success, otherwise false</returns>
+		public static bool UpdatePlatform(PlatformObject platform)
+        {
+			m_qryWrite.MakeFieldsNull();
+			m_qryWrite.PlatformID	= platform.PlatformID;
+			m_qryWrite.Name			= platform.Name;
+			m_qryWrite.Description	= platform.Description;
+			return m_qryWrite.Update() == SQLiteErrorCode.Ok;
+		}
+
+		/// <summary>
+		/// Remove platform with selected PlatformID from the database
+		/// </summary>
+		/// <param name="platformID">The platformID to delete</param>
+		/// <returns>True on delete success, otherwise false</returns>
+		public static bool RemovePlatform(int platformID)
+        {
+			m_qryWrite.MakeFieldsNull();
+			m_qryWrite.PlatformID = platformID;
+			return m_qryWrite.Delete() == SQLiteErrorCode.Ok;
+		}
+    }
+}

--- a/GameLauncher_Console/GameLauncher_Console/Platform.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Platform.cs
@@ -18,48 +18,38 @@ namespace GameLauncher_Console
         {
 			[Description("Unknown")]
 			Unknown = -1,
-			[Description("Favourites")]
-			Favourites = 0,
-			[Description("Custom games")]
-			Custom = 1,
-			[Description("All games")]
-			All = 2,
 			[Description("Steam")]
-			Steam = 3,
+			Steam = 0,
 			[Description("GOG Galaxy")]
-			GOG = 4,
+			GOG = 1,
 			[Description("Ubisoft Connect")]
-			Uplay = 5,
+			Uplay = 2,
 			[Description("Origin")]
-			Origin = 6,
+			Origin = 3,
 			[Description("Epic")]
-			Epic = 7,
+			Epic = 4,
 			[Description("Betheda.net")]
-			Bethesda = 8,
+			Bethesda = 5,
 			[Description("Battle.net")]
-			Battlenet = 9,
+			Battlenet = 6,
 			[Description("Rockstar")]
-			Rockstar = 10,
-			[Description("Hidden games")]
-			Hidden = 11,
-			[Description("Search results")]
-			Search = 12,
+			Rockstar = 7, 
 			[Description("Amazon")]
-			Amazon = 13,
+			Amazon = 8, 
 			[Description("Big Fish")]
-			BigFish = 14,
+			BigFish = 9, 
 			[Description("Arc")]
-			Arc = 15,
+			Arc = 10,
 			[Description("itch")]
-			Itch = 16,
+			Itch = 11,
 			[Description("Paradox")]
-			Paradox = 17,
+			Paradox = 12,
 			[Description("Plarium Play")]
-			Plarium = 18,
+			Plarium = 13,
 			[Description("Twitch")]
-			Twitch = 19,
+			Twitch = 14,
 			[Description("Wargaming.net")]
-			Wargaming = 20
+			Wargaming = 15,
 		}
 
 		#region Query definitions
@@ -168,15 +158,15 @@ namespace GameLauncher_Console
 		/// Get list of platforms from the database
 		/// </summary>
 		/// <returns>List of PlatformObjects</returns>
-		public static List<PlatformObject> GetPlatforms()
+		public static Dictionary<string, PlatformObject>GetPlatforms()
         {
-			List<PlatformObject> platforms = new List<PlatformObject>();
+			Dictionary<string, PlatformObject> platforms = new Dictionary<string, PlatformObject>();
 			m_qryRead.MakeFieldsNull();
 			if(m_qryRead.Select() == SQLiteErrorCode.Ok)
             {
 				do
 				{
-					platforms.Add(new PlatformObject(m_qryRead));
+					platforms[m_qryRead.Name] = new PlatformObject(m_qryRead);
 				} while(m_qryRead.Fetch());
             }
 			return platforms;
@@ -194,6 +184,20 @@ namespace GameLauncher_Console
 			m_qryWrite.Description	= platform.Description;
 			return m_qryWrite.Insert() == SQLiteErrorCode.Ok;
         }
+
+		/// <summary>
+		/// Insert specified platform into the database
+		/// </summary>
+		/// <param name="title">Platform title</param>
+		/// <param name="description">Platform description</param>
+		/// <returns>True on insert success, otherwise false</returns>
+		public static bool InsertPlatform(string title, string description)
+		{
+			m_qryWrite.MakeFieldsNull();
+			m_qryWrite.Name = title;
+			m_qryWrite.Description = description;
+			return m_qryWrite.Insert() == SQLiteErrorCode.Ok;
+		}
 
 		/// <summary>
 		/// Update specified platform

--- a/GameLauncher_Console/GameLauncher_Console/SqlDB.cs
+++ b/GameLauncher_Console/GameLauncher_Console/SqlDB.cs
@@ -118,15 +118,10 @@ namespace SqlDB
                     CLogger.LogError(e);
                     return SQLiteErrorCode.Unknown; // Use unknown for non-sql issues
                 }
-
                 if (script.Length > 0)
                 {
                     Execute(script);
                 }
-            }
-            else
-            {
-                return SQLiteErrorCode.Error;
             }
             return MaybeUpdateSchema();
         }
@@ -433,7 +428,7 @@ namespace SqlDB
                 {
                     query += ", ";
                 }
-                query += field.Key;
+                query += field.Value.Column;
             }
             return query;
         }
@@ -456,9 +451,8 @@ namespace SqlDB
                 }
                 if(field.Value.Type == TypeCode.String)
                 {
-                    insertValues += "'";
-                    insertValues += field.Value.String;
-                    insertValues += "'";
+                    string literal = StringToLiteral(field.Value.String);                   
+                    insertValues += literal;
                 }
                 else if(field.Value.Type == TypeCode.Double)
                 {
@@ -493,13 +487,12 @@ namespace SqlDB
                 {
                     whereCondition += " AND ";
                 }
-                whereCondition += field.Key;
+                whereCondition += field.Value.Column;
                 whereCondition += " = ";
                 if(field.Value.Type == TypeCode.String)
                 {
-                    whereCondition += "'";
-                    whereCondition += field.Value.String;
-                    whereCondition += "'";
+                    string literal = StringToLiteral(field.Value.String);
+                    whereCondition += literal;
                 }
                 else if(field.Value.Type == TypeCode.Double)
                 {
@@ -547,8 +540,8 @@ namespace SqlDB
                     }
                     else
                     {
-                        string s = "'" + m_sqlRow[columnIndex].String + "'";
-                        whereCondition.Replace(M_VALUE_MASK, s, vMask, 1);
+                        string literal = StringToLiteral(m_sqlRow[columnIndex].String);
+                        whereCondition.Replace(M_VALUE_MASK, literal, vMask, 1);
                     }
                 }
                 else if (m_sqlRow[columnIndex].Type == TypeCode.Double)
@@ -581,13 +574,12 @@ namespace SqlDB
                 {
                     update += ", ";
                 }
-                update += field.Key;
+                update += field.Value.Column;
                 update += " = ";
                 if (field.Value.Type == TypeCode.String)
                 {
-                    update += "'";
-                    update += field.Value.String;
-                    update += "'";
+                    string literal = StringToLiteral(field.Value.String);
+                    update += literal;
                 }
                 else if (field.Value.Type == TypeCode.Double)
                 {
@@ -599,6 +591,21 @@ namespace SqlDB
                 }
             }
             return update;
+        }
+
+        /// <summary>
+        /// Take a string input and return a literal, SQL-ready string
+        /// </summary>
+        /// <param name="input">The input string</param>
+        /// <returns>SQL-ready literal string</returns>
+        private string StringToLiteral(string input)
+        {
+            if(input == null)
+            {
+                return "''";
+            }
+            string literal = input.Replace("'", "''");
+            return "'" + literal + "'";
         }
 
         /// <summary>

--- a/GameLauncher_Console/UnitTest/DatabaseTest.cs
+++ b/GameLauncher_Console/UnitTest/DatabaseTest.cs
@@ -443,14 +443,14 @@ namespace UnitTest
             // Try to read (should fail)
             qry.PlatformID = 10;
             Assert.AreEqual(qry.Select(), SQLiteErrorCode.NotFound);
-            qry.ClearFields();
+            qry.MakeFieldsNull();
 
             // Insert new row
             qry.PlatformID = 10;
             qry.Name = "test 10";
             qry.Description = "PlatformID 10";
             Assert.AreEqual(qry.Insert(), SQLiteErrorCode.Ok);
-            qry.ClearFields();
+            qry.MakeFieldsNull();
 
             // Select new row
             qry.PlatformID = 10;
@@ -458,12 +458,12 @@ namespace UnitTest
             Assert.AreEqual(qry.PlatformID, 10);
             Assert.AreEqual(qry.Name, "test 10");
             Assert.AreEqual(qry.Description, "PlatformID 10");
-            qry.ClearFields();
+            qry.MakeFieldsNull();
 
             // Delete new row
             qry.PlatformID = 10;
             Assert.AreEqual(qry.Delete(), SQLiteErrorCode.Ok);
-            qry.ClearFields();
+            qry.MakeFieldsNull();
 
             // Try to read again (should fail)
             qry.PlatformID = 10;

--- a/GameLauncher_Console/UnitTest/DatabaseTest.cs
+++ b/GameLauncher_Console/UnitTest/DatabaseTest.cs
@@ -1,98 +1,36 @@
-﻿using GameLauncher_Console;
-using Logger;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Data.SQLite;
-using System.IO;
-using static GameLauncher_Console.CSqlField;
+using SqlDB;
+using static SqlDB.CSqlField;
 
 namespace UnitTest
 {
-    /// <summary>
-    /// Class for setting up tests
-    /// </summary>
-    public static class CTest_Setup
-    {
-        private static bool LoggerInit { get; set; }
-        private static bool RemovedDB  { get; set; }
-        private static bool OpenedDB   { get; set; }
-
-        private const string SQL_TEST_DATA_SOURCE = "test.db";
-
-        /// <summary>
-        /// Initialise log file
-        /// </summary>
-        public static void InitLogger()
-        {
-            if(LoggerInit)
-            {
-                return;
-            }
-#if DEBUG
-            // Log unhandled exceptions
-            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CLogger.ExceptionHandleEvent);
-#endif
-            CLogger.Configure(Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]) + ".log"); // Create a log file
-            CLogger.LogInfo("*************************");
-            LoggerInit = true;
-        }
-
-        /// <summary>
-        /// Setup test database tables and data
-        /// </summary>
-        public static void DatabaseSetup()
-        {
-            if(!OpenedDB && CSqlDB.Instance.Open(true, SQL_TEST_DATA_SOURCE) == SQLiteErrorCode.Ok)
-            {
-                OpenedDB = true;
-            }
-            CSqlDB.Instance.Execute("DELETE FROM Platform");
-            CSqlDB.Instance.Execute("insert into Platform (PlatformID, Name, Description) VALUES (1, 'test', 'PlatformID 1')");
-        }
-
-        /// <summary>
-        /// Delete database file
-        /// </summary>
-        public static void RemoveDatabase()
-        {
-            if(RemovedDB)
-            {
-                return;
-            }
-            if(File.Exists(SQL_TEST_DATA_SOURCE))
-            {
-                File.Delete(SQL_TEST_DATA_SOURCE);
-            }
-            RemovedDB = true;
-        }
-    }
-
-
     /// <summary>
     /// Test query for INSERT INTO ... statements
     /// </summary>
     public class CTest_InsertQry : CSqlQry
     {
-        public CTest_InsertQry() : base("Platform")
+        public CTest_InsertQry() 
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"]  = new CSqlFieldInteger("PlatformID", QryFlag.cInsWrite);
-            m_fields["Name"]        = new CSqlFieldString("Name", QryFlag.cInsWrite);
-            m_fields["Description"] = new CSqlFieldString("Description", QryFlag.cInsWrite);
+            m_sqlRow["PlatformID"]  = new CSqlFieldInteger("PlatformID", QryFlag.cInsWrite);
+            m_sqlRow["Name"]        = new CSqlFieldString("Name", QryFlag.cInsWrite);
+            m_sqlRow["Description"] = new CSqlFieldString("Description", QryFlag.cInsWrite);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
         public string Name
         {
-            get { return m_fields["Name"].String;   }
-            set { m_fields["Name"].String = value;  }
+            get { return m_sqlRow["Name"].String;   }
+            set { m_sqlRow["Name"].String = value;  }
         }
         public string Description
         {
-            get { return m_fields["Description"].String; }
-            set { m_fields["Description"].String = value; }
+            get { return m_sqlRow["Description"].String; }
+            set { m_sqlRow["Description"].String = value; }
         }
     }
 
@@ -101,26 +39,27 @@ namespace UnitTest
     /// </summary>
     public class CTest_SelectQry : CSqlQry
     {
-        public CTest_SelectQry() : base("Platform")
+        public CTest_SelectQry()
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cSelWhere);
-            m_fields["Name"]       = new CSqlFieldString("Name", QryFlag.cSelRead);
-            m_fields["Description"] = new CSqlFieldString("Description", QryFlag.cSelRead);
+            m_sqlRow["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cSelWhere);
+            m_sqlRow["Name"]       = new CSqlFieldString("Name", QryFlag.cSelRead);
+            m_sqlRow["Description"] = new CSqlFieldString("Description", QryFlag.cSelRead);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
         public string Name
         {
-            get { return m_fields["Name"].String; }
-            set { m_fields["Name"].String = value; }
+            get { return m_sqlRow["Name"].String; }
+            set { m_sqlRow["Name"].String = value; }
         }
         public string Description
         {
-            get { return m_fields["Description"].String; }
-            set { m_fields["Description"].String = value; }
+            get { return m_sqlRow["Description"].String; }
+            set { m_sqlRow["Description"].String = value; }
         }
     }
 
@@ -129,20 +68,21 @@ namespace UnitTest
     /// </summary>
     public class CTest_UpdateQry : CSqlQry
     {
-        public CTest_UpdateQry() : base("Platform")
+        public CTest_UpdateQry()
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cUpdWhere);
-            m_fields["Description"] = new CSqlFieldString("Description", QryFlag.cUpdWrite);
+            m_sqlRow["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cUpdWhere);
+            m_sqlRow["Description"] = new CSqlFieldString("Description", QryFlag.cUpdWrite);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
         public string Description
         {
-            get { return m_fields["Description"].String; }
-            set { m_fields["Description"].String = value; }
+            get { return m_sqlRow["Description"].String; }
+            set { m_sqlRow["Description"].String = value; }
         }
     }
 
@@ -151,14 +91,15 @@ namespace UnitTest
     /// </summary>
     public class CTest_DeleteQry : CSqlQry
     {
-        public CTest_DeleteQry() : base("Platform")
+        public CTest_DeleteQry()
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cDelWhere);
+            m_sqlRow["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cDelWhere);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
     }
 
@@ -167,26 +108,27 @@ namespace UnitTest
     /// </summary>
     public class CTest_SelectManyQry : CSqlQry
     {
-        public CTest_SelectManyQry() : base("Platform")
+        public CTest_SelectManyQry()
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cSelRead);
-            m_fields["Name"] = new CSqlFieldString("Name", QryFlag.cSelRead);
-            m_fields["Description"] = new CSqlFieldString("Description", QryFlag.cSelRead);
+            m_sqlRow["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cSelRead);
+            m_sqlRow["Name"] = new CSqlFieldString("Name", QryFlag.cSelRead);
+            m_sqlRow["Description"] = new CSqlFieldString("Description", QryFlag.cSelRead);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
         public string Name
         {
-            get { return m_fields["Name"].String; }
-            set { m_fields["Name"].String = value; }
+            get { return m_sqlRow["Name"].String; }
+            set { m_sqlRow["Name"].String = value; }
         }
         public string Description
         {
-            get { return m_fields["Description"].String; }
-            set { m_fields["Description"].String = value; }
+            get { return m_sqlRow["Description"].String; }
+            set { m_sqlRow["Description"].String = value; }
         }
     }
 
@@ -195,26 +137,27 @@ namespace UnitTest
     /// </summary>
     public class CTest_SelectMultiParamQry : CSqlQry
     {
-        public CTest_SelectMultiParamQry() : base("Platform")
+        public CTest_SelectMultiParamQry()
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cSelRead);
-            m_fields["Name"] = new CSqlFieldString("Name", QryFlag.cSelWhere);
-            m_fields["Description"] = new CSqlFieldString("Description", QryFlag.cSelWhere);
+            m_sqlRow["PlatformID"] = new CSqlFieldInteger("PlatformID", QryFlag.cSelRead);
+            m_sqlRow["Name"] = new CSqlFieldString("Name", QryFlag.cSelWhere);
+            m_sqlRow["Description"] = new CSqlFieldString("Description", QryFlag.cSelWhere);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
         public string Name
         {
-            get { return m_fields["Name"].String; }
-            set { m_fields["Name"].String = value; }
+            get { return m_sqlRow["Name"].String; }
+            set { m_sqlRow["Name"].String = value; }
         }
         public string Description
         {
-            get { return m_fields["Description"].String; }
-            set { m_fields["Description"].String = value; }
+            get { return m_sqlRow["Description"].String; }
+            set { m_sqlRow["Description"].String = value; }
         }
     }
 
@@ -223,26 +166,27 @@ namespace UnitTest
     /// </summary>
     public class CTest_MultiQry : CSqlQry
     {
-        public CTest_MultiQry() : base("Platform")
+        public CTest_MultiQry()
+            : base("Platform", "", "")
         {
-            m_fields["PlatformID"]  = new CSqlFieldInteger("PlatformID",    QryFlag.cInsWrite | QryFlag.cSelWhere | QryFlag.cUpdWhere | QryFlag.cDelWhere);
-            m_fields["Name"]        = new CSqlFieldString("Name",           QryFlag.cSelRead  | QryFlag.cUpdWrite | QryFlag.cInsWrite);
-            m_fields["Description"] = new CSqlFieldString("Description",    QryFlag.cSelRead  | QryFlag.cUpdWrite | QryFlag.cInsWrite);
+            m_sqlRow["PlatformID"]  = new CSqlFieldInteger("PlatformID",    QryFlag.cInsWrite | QryFlag.cSelWhere | QryFlag.cUpdWhere | QryFlag.cDelWhere);
+            m_sqlRow["Name"]        = new CSqlFieldString("Name",           QryFlag.cSelRead  | QryFlag.cUpdWrite | QryFlag.cInsWrite);
+            m_sqlRow["Description"] = new CSqlFieldString("Description",    QryFlag.cSelRead  | QryFlag.cUpdWrite | QryFlag.cInsWrite);
         }
         public int PlatformID
         {
-            get { return m_fields["PlatformID"].Integer; }
-            set { m_fields["PlatformID"].Integer = value; }
+            get { return m_sqlRow["PlatformID"].Integer; }
+            set { m_sqlRow["PlatformID"].Integer = value; }
         }
         public string Name
         {
-            get { return m_fields["Name"].String; }
-            set { m_fields["Name"].String = value; }
+            get { return m_sqlRow["Name"].String; }
+            set { m_sqlRow["Name"].String = value; }
         }
         public string Description
         {
-            get { return m_fields["Description"].String; }
-            set { m_fields["Description"].String = value; }
+            get { return m_sqlRow["Description"].String; }
+            set { m_sqlRow["Description"].String = value; }
         }
     }
 
@@ -256,9 +200,9 @@ namespace UnitTest
         [TestInitialize]
         public void Initialise()
         {
-            CTest_Setup.InitLogger();
-            CTest_Setup.RemoveDatabase();
-            CTest_Setup.DatabaseSetup(); // This is pretty much our test for creating a database and populating it with data, if this fails all tests will fail
+            CTestHelper.InitLogger();
+            CTestHelper.RemoveDatabase();
+            CTestHelper.DatabaseSetup(); // This is pretty much our test for creating a database and populating it with data, if this fails all tests will fail
         }
 
         /// <summary>

--- a/GameLauncher_Console/UnitTest/GameTest.cs
+++ b/GameLauncher_Console/UnitTest/GameTest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlDB;
+
+namespace UnitTest
+{
+    /// <summary>
+    /// Test class for any game-related logic
+    /// </summary>
+    [TestClass]
+    public class CGameTest
+    {
+        [TestInitialize]
+        public void Initialise()
+        {
+            CTestHelper.InitLogger();
+            CTestHelper.RemoveDatabase();
+            CTestHelper.DatabaseSetup(); // This is pretty much our test for creating a database and populating it with data, if this fails all tests will fail
+        }
+
+        /// <summary>
+        /// Open database
+        /// </summary>
+        [TestMethod]
+        public void Test_CreateDB()
+        {
+            Assert.IsTrue(CSqlDB.Instance.IsOpen());
+        }
+    }
+}

--- a/GameLauncher_Console/UnitTest/PlatformTest.cs
+++ b/GameLauncher_Console/UnitTest/PlatformTest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlDB;
+
+namespace UnitTest
+{
+    /// <summary>
+    /// Test class for any platform-related logic
+    /// </summary>
+    [TestClass]
+    public class CPlatformTest
+    {
+        [TestInitialize]
+        public void Initialise()
+        {
+            CTestHelper.InitLogger();
+            CTestHelper.RemoveDatabase();
+            CTestHelper.DatabaseSetup(); // This is pretty much our test for creating a database and populating it with data, if this fails all tests will fail
+        }
+
+        /// <summary>
+        /// Open database
+        /// </summary>
+        [TestMethod]
+        public void Test_CreateDB()
+        {
+            Assert.IsTrue(CSqlDB.Instance.IsOpen());
+        }
+    }
+}

--- a/GameLauncher_Console/UnitTest/TestHelper.cs
+++ b/GameLauncher_Console/UnitTest/TestHelper.cs
@@ -1,0 +1,67 @@
+﻿using Logger;
+using SqlDB;
+using System;
+using System.Data.SQLite;
+using System.IO;
+
+namespace UnitTest
+{
+    /// <summary>
+    /// Helper functions to aid in environment setup
+    /// </summary>
+    public static class CTestHelper
+    {
+        private static bool LoggerInit { get; set; }
+        private static bool RemovedDB { get; set; }
+        private static bool OpenedDB { get; set; }
+
+        private const string SQL_TEST_DATA_SOURCE = "test.db";
+
+        /// <summary>
+        /// Initialise log file
+        /// </summary>
+        public static void InitLogger()
+        {
+            if (LoggerInit)
+            {
+                return;
+            }
+#if DEBUG
+            // Log unhandled exceptions
+            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CLogger.ExceptionHandleEvent);
+#endif
+            CLogger.Configure(Path.GetFileNameWithoutExtension(Environment.GetCommandLineArgs()[0]) + ".log"); // Create a log file
+            CLogger.LogInfo("*************************");
+            LoggerInit = true;
+        }
+
+        /// <summary>
+        /// Setup test database tables and data
+        /// </summary>
+        public static void DatabaseSetup()
+        {
+            if (!OpenedDB && CSqlDB.Instance.Open(true, SQL_TEST_DATA_SOURCE) == SQLiteErrorCode.Ok)
+            {
+                OpenedDB = true;
+            }
+            CSqlDB.Instance.Execute("DELETE FROM Platform");
+            CSqlDB.Instance.Execute("insert into Platform (PlatformID, Name, Description) VALUES (1, 'test', 'PlatformID 1')");
+        }
+
+        /// <summary>
+        /// Delete database file
+        /// </summary>
+        public static void RemoveDatabase()
+        {
+            if (RemovedDB)
+            {
+                return;
+            }
+            if (File.Exists(SQL_TEST_DATA_SOURCE))
+            {
+                File.Delete(SQL_TEST_DATA_SOURCE);
+            }
+            RemovedDB = true;
+        }
+    }
+}

--- a/GameLauncher_Console/UnitTest/UnitTest.csproj
+++ b/GameLauncher_Console/UnitTest/UnitTest.csproj
@@ -74,7 +74,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DatabaseTest.cs" />
+    <Compile Include="PlatformTest.cs" />
+    <Compile Include="GameTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
- Added a JSON to database conversion tool;
  - The tool will read games from the JSON file, log them and save them to database
  - If game JSON file does not exist or otherwise needs refreshing, the tool will scan for games before and migration
  - The tool supports two modes:
    - Verify: load the games and log them (-verify cmd arg)
    - Apply: The same as verify + save games to database (-apply cmd arg)
  - NOTE: When in 'apply' mode, the tool will clear the platform and game tables
- Added two new classes, `CGame` and `CPlatform` to be used with the database
  - As of now both classes exist in separate namespace to the main program and are not integrated into the app
  - The classes serve as separation of platform and game logic (right now most of the logic is in the original game class) as well as SQL re-implementations (all of the sorting and searching logic can be moved to the SQL layer since it's faster)
- Added more unit tests

TODOs:
- Refactor the SQL core code (the `CSqlQry`-derived classes are full of repetitive, boilerplate code)
- Begin SQL integration into the app