### PR TITLE
GLC crashing when ARC is not installed

### DIFF
--- a/GameLauncher_Console/GameLauncher_Console/Platforms/Arc.cs
+++ b/GameLauncher_Console/GameLauncher_Console/Platforms/Arc.cs
@@ -87,6 +87,10 @@ namespace GameLauncher_Console
 
 			using (RegistryKey key = Registry.LocalMachine.OpenSubKey(Path.Combine(ARC_REG, ARC_GAMES), RegistryKeyPermissionCheck.ReadSubTree)) // HKLM32
 			{
+				if(key == null)
+                {
+					return;
+                }
 				foreach (string subKey in key.GetSubKeyNames()) // Add subkeys to search list
 				{
 					try


### PR DESCRIPTION
If the Registry key for ARC is not found, return out of the function.